### PR TITLE
SAAJ-81 Declaration parsing allocates too much

### DIFF
--- a/saaj-ri/src/java/com/sun/xml/messaging/saaj/util/XMLDeclarationParser.java
+++ b/saaj-ri/src/java/com/sun/xml/messaging/saaj/util/XMLDeclarationParser.java
@@ -91,10 +91,8 @@ public class XMLDeclarationParser {
      {
         int c = 0;
         int index = 0;
-        char[] aChar = new char[65535];
-        StringBuffer xmlDeclStr = new StringBuffer();
+        StringBuilder xmlDeclStr = new StringBuilder();
         while ((c = m_pushbackReader.read()) != -1) {
-            aChar[index] = (char)c;
             xmlDeclStr.append((char)c);
             index++;
             if (c == '>') {
@@ -119,7 +117,7 @@ public class XMLDeclarationParser {
 
         // no XML decl
         if (!utf16 && !utf8) {
-            m_pushbackReader.unread(aChar, 0, len);
+            m_pushbackReader.unread(decl.toCharArray(), 0, len);
             return;
         }
         m_hasHeader = true;


### PR DESCRIPTION
We're seeing a lot of allocation pressure due to declaration parsing.
XMLDeclarationParser always allocates a character array of size 65535.
This is quite excessive. Also it's not needed since all the content is
already in a StringBuffer.

Issue: SAAJ-81
https://java.net/jira/browse/SAAJ-81