### PR TITLE
Replace StringBuffer with StringBuilder

### DIFF
--- a/saaj-ri/src/java/com/sun/xml/messaging/saaj/client/p2p/HttpSOAPConnection.java
+++ b/saaj-ri/src/java/com/sun/xml/messaging/saaj/client/p2p/HttpSOAPConnection.java
@@ -224,7 +224,7 @@ class HttpSOAPConnection extends SOAPConnection {
                         header.getName(),
                         header.getValue());
                 else {
-                    StringBuffer concat = new StringBuffer();
+                    StringBuilder concat = new StringBuilder();
                     int i = 0;
                     while (i < values.length) {
                         if (i != 0)

--- a/saaj-ri/src/java/com/sun/xml/messaging/saaj/packaging/mime/MessagingException.java
+++ b/saaj-ri/src/java/com/sun/xml/messaging/saaj/packaging/mime/MessagingException.java
@@ -136,7 +136,7 @@ public class MessagingException extends Exception {
 	    return super.getMessage();
 	Exception n = next;
 	String s = super.getMessage();
-	StringBuffer sb = new StringBuffer(s == null ? "" : s);
+	StringBuilder sb = new StringBuilder(s == null ? "" : s);
 	while (n != null) {
 	    sb.append(";\n  nested exception is:\n\t");
 	    if (n instanceof MessagingException) {

--- a/saaj-ri/src/java/com/sun/xml/messaging/saaj/packaging/mime/internet/ContentDisposition.java
+++ b/saaj-ri/src/java/com/sun/xml/messaging/saaj/packaging/mime/internet/ContentDisposition.java
@@ -184,7 +184,7 @@ public class ContentDisposition {
 	if (list == null)
 	    return disposition;
 
-	StringBuffer sb = new StringBuffer(disposition);
+	StringBuilder sb = new StringBuilder(disposition);
 
         // append the parameter list  
         // use the length of the string buffer + the length of 

--- a/saaj-ri/src/java/com/sun/xml/messaging/saaj/packaging/mime/internet/ContentType.java
+++ b/saaj-ri/src/java/com/sun/xml/messaging/saaj/packaging/mime/internet/ContentType.java
@@ -219,7 +219,7 @@ public final class ContentType {
 	if (primaryType == null || subType == null) // need both
 	    return null;
 
-	StringBuffer sb = new StringBuffer();
+	StringBuilder sb = new StringBuilder();
 	sb.append(primaryType).append('/').append(subType);
 	if (list != null)
         // Http Binding section of the "SOAP with attachments" specification says,

--- a/saaj-ri/src/java/com/sun/xml/messaging/saaj/packaging/mime/internet/HeaderTokenizer.java
+++ b/saaj-ri/src/java/com/sun/xml/messaging/saaj/packaging/mime/internet/HeaderTokenizer.java
@@ -361,7 +361,7 @@ public class HeaderTokenizer {
      * quoted string.
      */
     private static String filterToken(String s, int start, int end) {
-	StringBuffer sb = new StringBuffer();
+	StringBuilder sb = new StringBuilder();
 	char c;
 	boolean gotEscape = false;
 	boolean gotCR = false;

--- a/saaj-ri/src/java/com/sun/xml/messaging/saaj/packaging/mime/internet/InternetHeaders.java
+++ b/saaj-ri/src/java/com/sun/xml/messaging/saaj/packaging/mime/internet/InternetHeaders.java
@@ -134,7 +134,7 @@ public final class InternetHeaders {
         LineInputStream lis = new LineInputStream(is);
         String prevline = null;	// the previous header line, as a string
         // a buffer to accumulate the header in, when we know it's needed
-        StringBuffer lineBuffer = new StringBuffer();
+        StringBuilder lineBuffer = new StringBuilder();
 
         try {
             //while ((line = lis.readLine()) != null) {
@@ -212,7 +212,7 @@ public final class InternetHeaders {
         if ((s.length == 1) || delimiter == null)
             return s[0];
 
-        StringBuffer r = new StringBuffer(s[0]);
+        StringBuilder r = new StringBuilder(s[0]);
         for (int i = 1; i < s.length; i++) {
             r.append(delimiter);
             r.append(s[i]);

--- a/saaj-ri/src/java/com/sun/xml/messaging/saaj/packaging/mime/internet/MimeBodyPart.java
+++ b/saaj-ri/src/java/com/sun/xml/messaging/saaj/packaging/mime/internet/MimeBodyPart.java
@@ -569,7 +569,7 @@ public final class MimeBodyPart {
      * @param languages 	array of language tags
      */
     public void setContentLanguage(String[] languages) {
-        StringBuffer sb = new StringBuffer(languages[0]);
+        StringBuilder sb = new StringBuilder(languages[0]);
         for (int i = 1; i < languages.length; i++)
             sb.append(',').append(languages[i]);
         setHeader("Content-Language", sb.toString());

--- a/saaj-ri/src/java/com/sun/xml/messaging/saaj/packaging/mime/internet/MimeUtility.java
+++ b/saaj-ri/src/java/com/sun/xml/messaging/saaj/packaging/mime/internet/MimeUtility.java
@@ -525,8 +525,8 @@ public class MimeUtility {
 	// Encoded words found. Start decoding ...
 
 	st = new StringTokenizer(etext, lwsp, true);
-	StringBuffer sb = new StringBuffer();  // decode buffer
-	StringBuffer wsb = new StringBuffer(); // white space buffer
+	StringBuilder sb = new StringBuilder();  // decode buffer
+	StringBuilder wsb = new StringBuilder(); // white space buffer
 	boolean prevWasEncoded = false;
 
 	while (st.hasMoreTokens()) {
@@ -663,7 +663,7 @@ public class MimeUtility {
 	    throw new UnsupportedEncodingException(
 			"Unknown transfer encoding: " + encoding);
 
-	StringBuffer outb = new StringBuffer(); // the output buffer
+	StringBuilder outb = new StringBuilder(); // the output buffer
 	doEncode(string, b64, jcharset, 
 		 // As per RFC 2047, size of an encoded string should not
 		 // exceed 75 bytes.
@@ -677,7 +677,7 @@ public class MimeUtility {
 
     private static void doEncode(String string, boolean b64, 
 		String jcharset, int avail, String prefix, 
-		boolean first, boolean encodingWord, StringBuffer buf) 
+		boolean first, boolean encodingWord, StringBuilder buf) 
 			throws UnsupportedEncodingException {
 
 	// First find out what the length of the encoded version of
@@ -827,7 +827,7 @@ public class MimeUtility {
     private static String decodeInnerWords(String word)
 				throws UnsupportedEncodingException {
 	int start = 0, i;
-	StringBuffer buf = new StringBuffer();
+	StringBuilder buf = new StringBuilder();
 	while ((i = word.indexOf("=?", start)) >= 0) {
 	    buf.append(word.substring(start, i));
 	    int end = word.indexOf("?=", i);
@@ -877,7 +877,7 @@ public class MimeUtility {
 	    char c = word.charAt(i);
 	    if (c == '"' || c == '\\' || c == '\r' || c == '\n') {
 		// need to escape them and then quote the whole string
-		StringBuffer sb = new StringBuffer(len + 3);
+		StringBuilder sb = new StringBuilder(len + 3);
 		sb.append('"');
 		sb.append(word.substring(0, i));
 		int lastc = 0;
@@ -900,7 +900,7 @@ public class MimeUtility {
 	}
 
 	if (needQuoting) {
-	    StringBuffer sb = new StringBuffer(len + 2);
+	    StringBuilder sb = new StringBuilder(len + 2);
 	    sb.append('"').append(word).append('"');
 	    return sb.toString();
 	} else 
@@ -942,7 +942,7 @@ public class MimeUtility {
 	    return s;
 
 	// have to actually fold the string
-	StringBuffer sb = new StringBuffer(s.length() + 4);
+	StringBuilder sb = new StringBuilder(s.length() + 4);
 	char lastc = 0;
 	while (used + s.length() > 76) {
 	    int lastspace = -1;
@@ -984,7 +984,7 @@ public class MimeUtility {
 	if (!foldText)
 	    return s;
 
-	StringBuffer sb = null;
+	StringBuilder sb = null;
 	int i;
 	while ((i = indexOfAny(s, "\r\n")) >= 0) {
 	    int start = i;
@@ -1001,7 +1001,7 @@ public class MimeUtility {
 		    while (i < l && ((c = s.charAt(i)) == ' ' || c == '\t'))
 			i++;
 		    if (sb == null)
-			sb = new StringBuffer(s.length());
+			sb = new StringBuilder(s.length());
 		    if (start != 0) {
 			sb.append(s.substring(0, start));
 			sb.append(' ');
@@ -1011,14 +1011,14 @@ public class MimeUtility {
 		}
 		// it's not a continuation line, just leave it in
 		if (sb == null)
-		    sb = new StringBuffer(s.length());
+		    sb = new StringBuilder(s.length());
 		sb.append(s.substring(0, i));
 		s = s.substring(i);
 	    } else {
 		// there's a backslash at "start - 1"
 		// strip it out, but leave in the line break
 		if (sb == null)
-		    sb = new StringBuffer(s.length());
+		    sb = new StringBuilder(s.length());
 		sb.append(s.substring(0, start - 1));
 		sb.append(s.substring(start, i));
 		s = s.substring(i);

--- a/saaj-ri/src/java/com/sun/xml/messaging/saaj/packaging/mime/internet/ParameterList.java
+++ b/saaj-ri/src/java/com/sun/xml/messaging/saaj/packaging/mime/internet/ParameterList.java
@@ -205,7 +205,7 @@ public final class ParameterList {
      * @return          String
      */  
     public String toString(int used) {
-        StringBuffer sb = new StringBuffer();
+    	StringBuilder sb = new StringBuilder();
         Iterator itr = list.entrySet().iterator();
 
         while (itr.hasNext()) {

--- a/saaj-ri/src/java/com/sun/xml/messaging/saaj/packaging/mime/internet/UniqueValue.java
+++ b/saaj-ri/src/java/com/sun/xml/messaging/saaj/packaging/mime/internet/UniqueValue.java
@@ -75,7 +75,7 @@ class UniqueValue {
      * and the current time (in milliseconds).
      */
     public static String getUniqueBoundaryValue() {
-	StringBuffer s = new StringBuffer();
+	StringBuilder s = new StringBuilder();
 
 	// Unique string is ----=_Part_<part>_<hashcode>.<currentTime>
 	s.append("----=_Part_").append(part++).append("_").

--- a/saaj-ri/src/java/com/sun/xml/messaging/saaj/soap/MessageImpl.java
+++ b/saaj-ri/src/java/com/sun/xml/messaging/saaj/soap/MessageImpl.java
@@ -1081,7 +1081,7 @@ public abstract class MessageImpl
     }
 
     private String convertToSingleLine(String contentType) {
-        StringBuffer buffer = new StringBuffer();
+        StringBuilder buffer = new StringBuilder();
         for (int i = 0; i < contentType.length(); i ++) {
             char c = contentType.charAt(i);
             if (c != '\r' && c != '\n' && c != '\t')

--- a/saaj-ri/src/java/com/sun/xml/messaging/saaj/util/Base64.java
+++ b/saaj-ri/src/java/com/sun/xml/messaging/saaj/util/Base64.java
@@ -259,7 +259,7 @@ public final class Base64 {
 
     public static String base64Decode( String orig ) {
 	char chars[]=orig.toCharArray();
-	StringBuffer sb=new StringBuffer();
+	StringBuilder sb=new StringBuilder();
 	int i=0;
 
 	int shift = 0;   // # of excess bits stored in accum

--- a/saaj-ri/src/java/com/sun/xml/messaging/saaj/util/JaxmURI.java
+++ b/saaj-ri/src/java/com/sun/xml/messaging/saaj/util/JaxmURI.java
@@ -740,7 +740,7 @@ import java.io.Serializable;
   * @return the scheme-specific part for this URI
   */
   public String getSchemeSpecificPart() {
-    StringBuffer schemespec = new StringBuffer();
+    StringBuilder schemespec = new StringBuilder();
 
     if (m_userinfo != null || m_host != null || m_port != -1) {
       schemespec.append("//");
@@ -820,7 +820,7 @@ import java.io.Serializable;
   */
   public String getPath(boolean p_includeQueryString,
                         boolean p_includeFragment) {
-    StringBuffer pathString = new StringBuffer(m_path);
+    StringBuilder pathString = new StringBuilder(m_path);
 
     if (p_includeQueryString && m_queryString != null) {
       pathString.append('?');
@@ -1163,7 +1163,7 @@ import java.io.Serializable;
   * @return the URI string specification
   */
   public String toString() {
-    StringBuffer uriSpecString = new StringBuffer();
+    StringBuilder uriSpecString = new StringBuilder();
 
     if (m_scheme != null) {
       uriSpecString.append(m_scheme);

--- a/saaj-ri/src/java/com/sun/xml/messaging/saaj/util/ParseUtil.java
+++ b/saaj-ri/src/java/com/sun/xml/messaging/saaj/util/ParseUtil.java
@@ -57,7 +57,7 @@ public class ParseUtil {
      * represent.
      */
     public static String decode(String s) {
-        StringBuffer sb = new StringBuffer();
+        StringBuilder sb = new StringBuilder();
 
         int i=0;
         while (i<s.length()) {


### PR DESCRIPTION
As of  release JDK 5 StringBuilder is preferred over StringBuffer for
use by a single thread as it supports all of the same operations
but it is faster, as it performs no synchronization.