### PR TITLE
Use generics

### DIFF
--- a/saaj-ri/src/java/com/sun/xml/messaging/saaj/client/p2p/HttpSOAPConnection.java
+++ b/saaj-ri/src/java/com/sun/xml/messaging/saaj/client/p2p/HttpSOAPConnection.java
@@ -110,7 +110,7 @@ class HttpSOAPConnection extends SOAPConnection {
             throw new SOAPExceptionImpl("Connection is closed");
         }
 
-        Class urlEndpointClass = null;
+        Class<?> urlEndpointClass = null;
         ClassLoader loader = Thread.currentThread().getContextClassLoader();
         try {
             if (loader != null) {
@@ -213,7 +213,7 @@ class HttpSOAPConnection extends SOAPConnection {
 
             MimeHeaders headers = message.getMimeHeaders();
 
-            Iterator it = headers.getAllHeaders();
+            Iterator<?> it = headers.getAllHeaders();
             boolean hasAuth = false; // true if we find explicit Auth header
             while (it.hasNext()) {
                 MimeHeader header = (MimeHeader) it.next();
@@ -370,7 +370,7 @@ class HttpSOAPConnection extends SOAPConnection {
             log.severe("SAAJ0011.p2p.get.already.closed.conn");
             throw new SOAPExceptionImpl("Connection is closed");
         }
-        Class urlEndpointClass = null;
+        Class<?> urlEndpointClass = null;
 
         try {
             urlEndpointClass = Class.forName("javax.xml.messaging.URLEndpoint");
@@ -606,7 +606,7 @@ class HttpSOAPConnection extends SOAPConnection {
                 log.log(Level.FINE, "SAAJ0054.p2p.set.providers",
                         new String[] { pkgs });
             try {
-                Class c = Class.forName(SSL_PROVIDER);
+                Class<?> c = Class.forName(SSL_PROVIDER);
                 Provider p = (Provider) c.newInstance();
                 Security.addProvider(p);
                 if (log.isLoggable(Level.FINE))

--- a/saaj-ri/src/java/com/sun/xml/messaging/saaj/packaging/mime/internet/BMMimeMultipart.java
+++ b/saaj-ri/src/java/com/sun/xml/messaging/saaj/packaging/mime/internet/BMMimeMultipart.java
@@ -720,7 +720,7 @@ public  class BMMimeMultipart extends MimeMultipart {
         String bnd = "--" + contentType.getParameter("boundary");
         for (int i = 0; i < parts.size(); i++) {
             OutputUtil.writeln(bnd, os); // put out boundary
-            ((MimeBodyPart)parts.get(i)).writeTo(os);
+            parts.get(i).writeTo(os);
             OutputUtil.writeln(os); // put out empty line
         }
                                                                                 

--- a/saaj-ri/src/java/com/sun/xml/messaging/saaj/packaging/mime/internet/InternetHeaders.java
+++ b/saaj-ri/src/java/com/sun/xml/messaging/saaj/packaging/mime/internet/InternetHeaders.java
@@ -88,12 +88,12 @@ import java.util.NoSuchElementException;
  */
 public final class InternetHeaders {
 
-    private final FinalArrayList headers = new FinalArrayList();
+    private final FinalArrayList<hdr> headers = new FinalArrayList<hdr>();
 
     /**
      * Lazily cerated view of header lines (Strings).
      */
-    private List headerValueView;
+    private List<String> headerValueView;
 
     /**
      * Create an empty InternetHeaders object.
@@ -176,11 +176,11 @@ public final class InternetHeaders {
      */
     public String[] getHeader(String name) {
         // XXX - should we just step through in index order?
-        FinalArrayList v = new FinalArrayList(); // accumulate return values
+        FinalArrayList<String> v = new FinalArrayList<String>(); // accumulate return values
 
         int len = headers.size();
         for( int i=0; i<len; i++ ) {
-            hdr h = (hdr) headers.get(i);
+            hdr h = headers.get(i);
             if (name.equalsIgnoreCase(h.name)) {
                 v.add(h.getValue());
             }
@@ -188,7 +188,7 @@ public final class InternetHeaders {
         if (v.size() == 0)
             return (null);
         // convert Vector to an array for return
-        return (String[]) v.toArray(new String[v.size()]);
+        return v.toArray(new String[v.size()]);
     }
 
     /**
@@ -234,7 +234,7 @@ public final class InternetHeaders {
         boolean found = false;
 
         for (int i = 0; i < headers.size(); i++) {
-            hdr h = (hdr) headers.get(i);
+            hdr h = headers.get(i);
             if (name.equalsIgnoreCase(h.name)) {
                 if (!found) {
                     int j;
@@ -267,7 +267,7 @@ public final class InternetHeaders {
     public void addHeader(String name, String value) {
         int pos = headers.size();
         for (int i = headers.size() - 1; i >= 0; i--) {
-            hdr h = (hdr) headers.get(i);
+            hdr h = headers.get(i);
             if (name.equalsIgnoreCase(h.name)) {
                 headers.add(i + 1, new hdr(name, value));
                 return;
@@ -286,7 +286,7 @@ public final class InternetHeaders {
      */
     public void removeHeader(String name) {
         for (int i = 0; i < headers.size(); i++) {
-            hdr h = (hdr) headers.get(i);
+            hdr h = headers.get(i);
             if (name.equalsIgnoreCase(h.name)) {
                 headers.remove(i);
                 i--;    // have to look at i again
@@ -300,7 +300,7 @@ public final class InternetHeaders {
      *
      * @return	Header objects
      */
-    public FinalArrayList getAllHeaders() {
+    public FinalArrayList<hdr> getAllHeaders() {
         return headers; // conceptually it should be read-only, but for performance reason I'm not wrapping it here
     }
 
@@ -317,7 +317,7 @@ public final class InternetHeaders {
         try {
             char c = line.charAt(0);
             if (c == ' ' || c == '\t') {
-                hdr h = (hdr) headers.get(headers.size() - 1);
+                hdr h = headers.get(headers.size() - 1);
                 h.line += "\r\n" + line;
             } else
                 headers.add(new hdr(line));
@@ -332,11 +332,11 @@ public final class InternetHeaders {
     /**
      * Return all the header lines as a collection
      */
-    public List getAllHeaderLines() {
+    public List<String> getAllHeaderLines() {
         if(headerValueView==null)
-            headerValueView = new AbstractList() {
-                public Object get(int index) {
-                    return ((hdr)headers.get(index)).line;
+            headerValueView = new AbstractList<String>() {
+                public String get(int index) {
+                    return headers.get(index).line;
                 }
 
                 public int size() {

--- a/saaj-ri/src/java/com/sun/xml/messaging/saaj/packaging/mime/internet/MimeBodyPart.java
+++ b/saaj-ri/src/java/com/sun/xml/messaging/saaj/packaging/mime/internet/MimeBodyPart.java
@@ -541,7 +541,7 @@ public final class MimeBodyPart {
 
         // Tokenize the header to obtain the Language-tags (skip comments)
         HeaderTokenizer h = new HeaderTokenizer(s, HeaderTokenizer.MIME);
-        FinalArrayList v = new FinalArrayList();
+        FinalArrayList<String> v = new FinalArrayList<String>();
 
         HeaderTokenizer.Token tk;
         int tkType;
@@ -559,7 +559,7 @@ public final class MimeBodyPart {
         if (v.size() == 0)
             return null;
 
-        return (String[])v.toArray(new String[v.size()]);
+        return v.toArray(new String[v.size()]);
     }
 
     /**
@@ -958,10 +958,10 @@ public final class MimeBodyPart {
 				throws IOException, MessagingException {
 
         // First, write out the header
-        List hdrLines = headers.getAllHeaderLines();
+        List<String> hdrLines = headers.getAllHeaderLines();
         int sz = hdrLines.size();
         for( int i=0; i<sz; i++ )
-            OutputUtil.writeln((String)hdrLines.get(i),os);
+            OutputUtil.writeln(hdrLines.get(i),os);
 
         // The CRLF separator between header and content
         OutputUtil.writeln(os);
@@ -1058,7 +1058,7 @@ public final class MimeBodyPart {
      * Return all the headers from this Message as an Enumeration of
      * Header objects.
      */
-    public FinalArrayList getAllHeaders() {
+    public FinalArrayList<hdr> getAllHeaders() {
         return headers.getAllHeaders();
     }
 

--- a/saaj-ri/src/java/com/sun/xml/messaging/saaj/packaging/mime/internet/MimeMultipart.java
+++ b/saaj-ri/src/java/com/sun/xml/messaging/saaj/packaging/mime/internet/MimeMultipart.java
@@ -108,7 +108,7 @@ public  class MimeMultipart {
     /**
      * Vector of MimeBodyPart objects.
      */
-    protected FinalArrayList parts = new FinalArrayList(); // Holds BodyParts
+    protected FinalArrayList<MimeBodyPart> parts = new FinalArrayList<MimeBodyPart>(); // Holds BodyParts
 
     /**
      * This field specifies the content-type of this multipart
@@ -227,7 +227,7 @@ public  class MimeMultipart {
         if (parts == null)
             throw new IndexOutOfBoundsException("No such BodyPart");
 
-        return (MimeBodyPart)parts.get(index);
+        return parts.get(index);
     }
 
     /**
@@ -274,7 +274,7 @@ public  class MimeMultipart {
      */
     protected void updateHeaders() throws MessagingException {
 	for (int i = 0; i < parts.size(); i++)
-	    ((MimeBodyPart)parts.get(i)).updateHeaders();
+	    parts.get(i).updateHeaders();
     }
 
     /**
@@ -611,7 +611,7 @@ public  class MimeMultipart {
 	if (parts == null)
 	    throw new IndexOutOfBoundsException("No such BodyPart");
 
-	MimeBodyPart part = (MimeBodyPart)parts.get(index);
+	MimeBodyPart part = parts.get(index);
 	parts.remove(index);
 	part.setParent(null);
     }
@@ -624,7 +624,7 @@ public  class MimeMultipart {
      */
     public synchronized void addBodyPart(MimeBodyPart part) {
 	if (parts == null)
-	    parts = new FinalArrayList();
+	    parts = new FinalArrayList<MimeBodyPart>();
 
 	parts.add(part);
 	part.setParent(this);
@@ -642,7 +642,7 @@ public  class MimeMultipart {
      */
     public synchronized void addBodyPart(MimeBodyPart part, int index) {
 	if (parts == null)
-	    parts = new FinalArrayList();
+	    parts = new FinalArrayList<MimeBodyPart>();
 
 	parts.add(index,part);
 	part.setParent(this);

--- a/saaj-ri/src/java/com/sun/xml/messaging/saaj/packaging/mime/internet/MimeUtility.java
+++ b/saaj-ri/src/java/com/sun/xml/messaging/saaj/packaging/mime/internet/MimeUtility.java
@@ -1066,7 +1066,7 @@ public class MimeUtility {
 	    // no mapping table, or charset parameter is null
 	    return charset;
 
-	String alias = (String)mime2java.get(charset.toLowerCase());
+	String alias = mime2java.get(charset.toLowerCase());
 	return alias == null ? charset : alias;
     }
 
@@ -1088,7 +1088,7 @@ public class MimeUtility {
 	    // no mapping table or charset param is null
 	    return charset;
 
-	String alias = (String)java2mime.get(charset.toLowerCase());
+	String alias = java2mime.get(charset.toLowerCase());
 	return alias == null ? charset : alias;
     }
 
@@ -1155,12 +1155,12 @@ public class MimeUtility {
 
     // Tables to map MIME charset names to Java names and vice versa.
     // XXX - Should eventually use J2SE 1.4 java.nio.charset.Charset
-    private static Hashtable mime2java;
-    private static Hashtable java2mime;
+    private static Hashtable<String, String> mime2java;
+    private static Hashtable<String, String> java2mime;
 
     static {
-	java2mime = new Hashtable(40);
-	mime2java = new Hashtable(10);
+	java2mime = new Hashtable<String, String>(40);
+	mime2java = new Hashtable<String, String>(10);
 
 	try {
 	    // Use this class's classloader to load the mapping file
@@ -1244,7 +1244,7 @@ public class MimeUtility {
 	}
     }
 
-    private static void loadMappings(LineInputStream is, Hashtable table) {
+    private static void loadMappings(LineInputStream is, Hashtable<String, String> table) {
 	String currLine;
 
 	while (true) {

--- a/saaj-ri/src/java/com/sun/xml/messaging/saaj/packaging/mime/internet/ParameterList.java
+++ b/saaj-ri/src/java/com/sun/xml/messaging/saaj/packaging/mime/internet/ParameterList.java
@@ -59,16 +59,16 @@ import java.util.Map;
 
 public final class ParameterList {
 
-    private final HashMap list;
+    private final HashMap<String, String> list;
 
     /**
      * No-arg Constructor.
      */
     public ParameterList() {
-        this.list = new HashMap();
+        this.list = new HashMap<String, String>();
     }
 
-    private ParameterList(HashMap m) {
+    private ParameterList(HashMap<String, String> m) {
         this.list = m;
     }
 
@@ -88,7 +88,7 @@ public final class ParameterList {
 	int type;
 	String name;
 
-        list = new HashMap();
+        list = new HashMap<String, String>();
 	while (true) {
 	    tk = h.next();
 	    type = tk.getType();
@@ -145,7 +145,7 @@ public final class ParameterList {
      *			present.
      */
     public String get(String name) {
-	return (String)list.get(name.trim().toLowerCase());
+	return list.get(name.trim().toLowerCase());
     }
 
     /**
@@ -175,7 +175,7 @@ public final class ParameterList {
      *
      * @return Enumeration of all parameter names in this list.
      */
-    public Iterator getNames() {
+    public Iterator<String> getNames() {
 	return list.keySet().iterator();
     }
     
@@ -206,12 +206,12 @@ public final class ParameterList {
      */  
     public String toString(int used) {
         StringBuffer sb = new StringBuffer();
-        Iterator itr = list.entrySet().iterator();
+        Iterator<Map.Entry<String, String>> itr = list.entrySet().iterator();
 
         while (itr.hasNext()) {
-            Map.Entry e = (Map.Entry)itr.next();
-            String name = (String)e.getKey();
-            String value = quote((String)e.getValue());
+            Map.Entry<String, String> e = itr.next();
+            String name = e.getKey();
+            String value = quote(e.getValue());
             sb.append("; ");
             used += 2;
             int len = name.length() + value.length() + 1;

--- a/saaj-ri/src/java/com/sun/xml/messaging/saaj/soap/ContextClassloaderLocal.java
+++ b/saaj-ri/src/java/com/sun/xml/messaging/saaj/soap/ContextClassloaderLocal.java
@@ -85,9 +85,8 @@ abstract class ContextClassloaderLocal<V> {
     }
 
     private static ClassLoader getContextClassLoader() {
-        return (ClassLoader)
-                AccessController.doPrivileged(new PrivilegedAction() {
-                    public Object run() {
+        return AccessController.doPrivileged(new PrivilegedAction<ClassLoader>() {
+                    public ClassLoader run() {
                         ClassLoader cl = null;
                         try {
                             cl = Thread.currentThread().getContextClassLoader();

--- a/saaj-ri/src/java/com/sun/xml/messaging/saaj/soap/ImageDataContentHandler.java
+++ b/saaj-ri/src/java/com/sun/xml/messaging/saaj/soap/ImageDataContentHandler.java
@@ -146,9 +146,9 @@ public class ImageDataContentHandler extends Component
                     + obj.getClass().toString());
             }
             ImageWriter writer = null;
-            Iterator i = ImageIO.getImageWritersByMIMEType(type);
+            Iterator<ImageWriter> i = ImageIO.getImageWritersByMIMEType(type);
             if (i.hasNext()) {
-                writer = (ImageWriter)i.next();
+                writer = i.next();
             }
             if (writer != null) {
                 ImageOutputStream stream = null;

--- a/saaj-ri/src/java/com/sun/xml/messaging/saaj/soap/MessageImpl.java
+++ b/saaj-ri/src/java/com/sun/xml/messaging/saaj/soap/MessageImpl.java
@@ -98,7 +98,7 @@ public abstract class MessageImpl
     protected MimeHeaders headers;
     protected ContentType contentType;
     protected SOAPPartImpl soapPartImpl;
-    protected FinalArrayList attachments;
+    protected FinalArrayList<AttachmentPart> attachments;
     protected boolean saved = false;
     protected byte[] messageBytes;
     protected int messageByteCount;
@@ -870,7 +870,7 @@ public abstract class MessageImpl
             throw new RuntimeException(e);
         }
         if (attachments == null)
-            attachments = new FinalArrayList();
+            attachments = new FinalArrayList<AttachmentPart>();
 
         attachments.add(attachment);
 
@@ -902,15 +902,15 @@ public abstract class MessageImpl
         headers.setHeader("Content-Type", ct.toString());
     }
 
-    private class MimeMatchingIterator implements Iterator {
+    private class MimeMatchingIterator implements Iterator<AttachmentPart> {
         public MimeMatchingIterator(MimeHeaders headers) {
             this.headers = headers;
             this.iter = attachments.iterator();
         }
 
-        private Iterator iter;
+        private Iterator<AttachmentPart> iter;
         private MimeHeaders headers;
-        private Object nextAttachment;
+        private AttachmentPart nextAttachment;
 
         public boolean hasNext() {
             if (nextAttachment == null)
@@ -918,9 +918,9 @@ public abstract class MessageImpl
             return nextAttachment != null;
         }
 
-        public Object next() {
+        public AttachmentPart next() {
             if (nextAttachment != null) {
-                Object ret = nextAttachment;
+            	AttachmentPart ret = nextAttachment;
                 nextAttachment = null;
                 return ret;
             }
@@ -931,7 +931,7 @@ public abstract class MessageImpl
             return null;
         }
 
-        Object nextMatch() {
+        AttachmentPart nextMatch() {
             while (iter.hasNext()) {
                 AttachmentPartImpl ap = (AttachmentPartImpl) iter.next();
                 if (ap.hasAllHeaders(headers))
@@ -966,12 +966,12 @@ public abstract class MessageImpl
         if (attachments == null)
             return ;
 
-        Iterator it =  new MimeMatchingIterator(headers);
+        Iterator<AttachmentPart> it =  new MimeMatchingIterator(headers);
         while (it.hasNext()) {
             int index = attachments.indexOf(it.next());
             attachments.set(index, null);
         }
-        FinalArrayList f = new FinalArrayList();
+        FinalArrayList<AttachmentPart> f = new FinalArrayList<AttachmentPart>();
         for (int i = 0; i < attachments.size(); i++) {
             if (attachments.get(i) != null) {
                 f.add(attachments.get(i));
@@ -1113,7 +1113,7 @@ public abstract class MessageImpl
                 headerAndBody = new BMMimeMultipart();
                 headerAndBody.addBodyPart(mimeSoapPart);
                 if (attachments != null) { 
-                    for (Iterator eachAttachment = attachments.iterator();
+                    for (Iterator<AttachmentPart> eachAttachment = attachments.iterator();
                          eachAttachment.hasNext();) {
                         headerAndBody.addBodyPart(
                             ((AttachmentPartImpl) eachAttachment.next())
@@ -1439,7 +1439,7 @@ public abstract class MessageImpl
         }
                                                                                 
         if (attachments == null)
-            attachments = new FinalArrayList();
+            attachments = new FinalArrayList<AttachmentPart>();
                                                                                 
         int count = multiPart.getCount();
         for (int i=0; i < count; i++ ) {

--- a/saaj-ri/src/java/com/sun/xml/messaging/saaj/soap/XmlDataContentHandler.java
+++ b/saaj-ri/src/java/com/sun/xml/messaging/saaj/soap/XmlDataContentHandler.java
@@ -59,7 +59,7 @@ import com.sun.xml.messaging.saaj.util.transform.EfficientStreamingTransformer;
  */
 public class XmlDataContentHandler implements DataContentHandler {
     public static final String STR_SRC = "javax.xml.transform.stream.StreamSource";
-    private static Class streamSourceClass = null;
+    private static Class<?> streamSourceClass = null;
 
     public XmlDataContentHandler() throws ClassNotFoundException {
         if (streamSourceClass == null) {

--- a/saaj-ri/src/java/com/sun/xml/messaging/saaj/soap/impl/BodyImpl.java
+++ b/saaj-ri/src/java/com/sun/xml/messaging/saaj/soap/impl/BodyImpl.java
@@ -146,7 +146,7 @@ public abstract class BodyImpl extends ElementImpl implements SOAPBody {
     }
 
     protected SOAPElement findFault() {
-        Iterator eachChild = getChildElementNodes();
+        Iterator<Node> eachChild = getChildElementNodes();
         while (eachChild.hasNext()) {
             SOAPElement child = (SOAPElement) eachChild.next();
             if (isFault(child)) {
@@ -262,7 +262,7 @@ public abstract class BodyImpl extends ElementImpl implements SOAPBody {
             org.w3c.dom.Node replacingNode = ownerDoc.importNode(docFrag, true);
             // Adding replacingNode at the last of the children list of body
             addNode(replacingNode);
-            Iterator i =
+            Iterator<Node> i =
                 getChildElements(NameImpl.copyElementName(rootElement));
             // Return the child element with the required name which is at the
             // end of the list
@@ -299,7 +299,7 @@ public abstract class BodyImpl extends ElementImpl implements SOAPBody {
 
     public Document extractContentAsDocument() throws SOAPException {
 
-        Iterator eachChild = getChildElements();
+        Iterator<Node> eachChild = getChildElements();
         javax.xml.soap.Node firstBodyElement = null;
 
         while (eachChild.hasNext() &&

--- a/saaj-ri/src/java/com/sun/xml/messaging/saaj/soap/impl/DetailImpl.java
+++ b/saaj-ri/src/java/com/sun/xml/messaging/saaj/soap/impl/DetailImpl.java
@@ -92,8 +92,8 @@ public abstract class DetailImpl extends FaultElementImpl implements Detail {
     }
 
     public Iterator getDetailEntries() {
-        return new Iterator() {
-            Iterator eachNode = getChildElementNodes();
+        return new Iterator<SOAPElement>() {
+            Iterator<org.w3c.dom.Node> eachNode = getChildElementNodes();
             SOAPElement next = null;
             SOAPElement last = null;
 
@@ -110,7 +110,7 @@ public abstract class DetailImpl extends FaultElementImpl implements Detail {
                 return next != null;
             }
 
-            public Object next() {
+            public SOAPElement next() {
                 if (!hasNext()) {
                     throw new NoSuchElementException();
                 }

--- a/saaj-ri/src/java/com/sun/xml/messaging/saaj/soap/impl/ElementImpl.java
+++ b/saaj-ri/src/java/com/sun/xml/messaging/saaj/soap/impl/ElementImpl.java
@@ -354,7 +354,7 @@ public class ElementImpl
                    log.severe("SAAJ0158.impl.version.mismatch.fault");
                    throw new SOAPExceptionImpl("SOAP Version mismatch encountered when trying to add SOAPFault to SOAPBody");
                }
-               Iterator it = this.getChildElements();
+               Iterator<Node> it = this.getChildElements();
                if (it.hasNext()) {
                    log.severe("SAAJ0156.impl.adding.fault.error");
                    throw new SOAPExceptionImpl("Cannot add SOAPFault as a child of a non-Empty SOAPBody");
@@ -465,7 +465,7 @@ public class ElementImpl
     }
 
     protected SOAPElement findAndConvertChildElement(NameImpl name) {
-        Iterator eachChild = getChildElementNodes();
+        Iterator<Node> eachChild = getChildElementNodes();
         while (eachChild.hasNext()) {
             SOAPElement child = (SOAPElement) eachChild.next();
             if (child.getElementName().equals(name)) {
@@ -575,10 +575,10 @@ public class ElementImpl
     }
 
     public Iterator getAllAttributes() {
-        Iterator i = getAllAttributesFrom(this);
-        ArrayList list = new ArrayList();
+        Iterator<Name> i = getAllAttributesFrom(this);
+        ArrayList<Name> list = new ArrayList<Name>();
         while (i.hasNext()) {
-            Name name = (Name) i.next();
+            Name name = i.next();
             if (!"xmlns".equalsIgnoreCase(name.getPrefix()))
                 list.add(name);
         }
@@ -586,10 +586,10 @@ public class ElementImpl
     }
 
     public Iterator getAllAttributesAsQNames() {
-        Iterator i = getAllAttributesFrom(this);
-        ArrayList list = new ArrayList();
+        Iterator<Name> i = getAllAttributesFrom(this);
+        ArrayList<QName> list = new ArrayList<QName>();
         while (i.hasNext()) {
-            Name name = (Name) i.next();
+            Name name = i.next();
             if (!"xmlns".equalsIgnoreCase(name.getPrefix())) {
                 list.add(NameImpl.convertToQName(name));
             }
@@ -606,8 +606,8 @@ public class ElementImpl
         return doGetNamespacePrefixes(true);
     }
 
-    protected Iterator doGetNamespacePrefixes(final boolean deep) {
-        return new Iterator() {
+    protected Iterator<String> doGetNamespacePrefixes(final boolean deep) {
+        return new Iterator<String>() {
             String next = null;
             String last = null;
             NamespaceContextIterator eachNamespace =
@@ -628,7 +628,7 @@ public class ElementImpl
                 return next != null;
             }
 
-            public Object next() {
+            public String next() {
                 findNext();
                 if (next == null) {
                     throw new NoSuchElementException();
@@ -691,7 +691,7 @@ public class ElementImpl
         return true;
     }
 
-    public Iterator getChildElements() {
+    public Iterator<Node> getChildElements() {
         return getChildElementsFrom(this);
     }
 
@@ -709,15 +709,15 @@ public class ElementImpl
         Element element,
         ElementImpl copy) {
 
-        Iterator eachAttribute = getAllAttributesFrom(element);
+        Iterator<Name> eachAttribute = getAllAttributesFrom(element);
         while (eachAttribute.hasNext()) {
-            Name name = (Name) eachAttribute.next();
+            Name name = eachAttribute.next();
             copy.addAttributeBare(name, getAttributeValueFrom(element, name));
         }
         
-        Iterator eachChild = getChildElementsFrom(element);
+        Iterator<Node> eachChild = getChildElementsFrom(element);
         while (eachChild.hasNext()) {
-            Node nextChild = (Node) eachChild.next();
+            Node nextChild = eachChild.next();
             copy.insertBefore(nextChild, null);
         }
 
@@ -729,16 +729,16 @@ public class ElementImpl
         return copy;
     }
 
-    protected Iterator getChildElementNodes() {
-        return new Iterator() {
-            Iterator eachNode = getChildElements();
+    protected Iterator<Node> getChildElementNodes() {
+        return new Iterator<Node>() {
+            Iterator<Node> eachNode = getChildElements();
             Node next = null;
             Node last = null;
 
             public boolean hasNext() {
                 if (next == null) {
                     while (eachNode.hasNext()) {
-                        Node node = (Node) eachNode.next();
+                        Node node = eachNode.next();
                         if (node instanceof SOAPElement) {
                             next = node;
                             break;
@@ -748,7 +748,7 @@ public class ElementImpl
                 return next != null;
             }
 
-            public Object next() {
+            public Node next() {
                 if (hasNext()) {
                     last = next;
                     next = null;
@@ -776,16 +776,16 @@ public class ElementImpl
         return getChildElements(qname.getNamespaceURI(), qname.getLocalPart());
     }
     
-    private Iterator getChildElements(final String nameUri, final String nameLocal) {
-        return new Iterator() {
-            Iterator eachElement = getChildElementNodes();
+    private Iterator<Node> getChildElements(final String nameUri, final String nameLocal) {
+        return new Iterator<Node>() {
+            Iterator<Node> eachElement = getChildElementNodes();
             Node next = null;
             Node last = null;
 
             public boolean hasNext() {
                 if (next == null) {
                     while (eachElement.hasNext()) {
-                        Node element = (Node) eachElement.next();
+                        Node element = eachElement.next();
                         String elementUri = element.getNamespaceURI();
                         elementUri = elementUri == null ? "" : elementUri;
                         String elementName = element.getLocalName();
@@ -799,7 +799,7 @@ public class ElementImpl
                 return next != null;
             }
 
-            public Object next() {
+            public Node next() {
                 if (!hasNext()) {
                     throw new NoSuchElementException();
                 }
@@ -909,7 +909,7 @@ public class ElementImpl
     }
 
     protected javax.xml.soap.Node getValueNode() {
-        Iterator i = getChildElements();
+        Iterator<Node> i = getChildElements();
         while (i.hasNext()) {
             javax.xml.soap.Node n = (javax.xml.soap.Node) i.next();
             if (n.getNodeType() == org.w3c.dom.Node.TEXT_NODE ||
@@ -1069,10 +1069,10 @@ public class ElementImpl
         return null;
     }
 
-    protected static Iterator getAllAttributesFrom(final Element element) {
+    protected static Iterator<Name> getAllAttributesFrom(final Element element) {
         final NamedNodeMap attributes = element.getAttributes();
 
-        return new Iterator() {
+        return new Iterator<Name>() {
             int attributesLength = attributes.getLength();
             int attributeIndex = 0;
             String currentName;
@@ -1081,7 +1081,7 @@ public class ElementImpl
                 return attributeIndex < attributesLength;
             }
 
-            public Object next() {
+            public Name next() {
                 if (!hasNext()) {
                     throw new NoSuchElementException();
                 }
@@ -1148,8 +1148,8 @@ public class ElementImpl
         return attribute == null ? null : attribute.getValue();
     }
 
-    protected static Iterator getChildElementsFrom(final Element element) {
-        return new Iterator() {
+    protected static Iterator<Node> getChildElementsFrom(final Element element) {
+        return new Iterator<Node>() {
             Node next = element.getFirstChild();
             Node nextNext = null;
             Node last = null;
@@ -1165,7 +1165,7 @@ public class ElementImpl
                 return next != null;
             }
 
-            public Object next() {
+            public Node next() {
                 if (hasNext()) {
                     last = next;
                     next = null;

--- a/saaj-ri/src/java/com/sun/xml/messaging/saaj/soap/impl/HeaderImpl.java
+++ b/saaj-ri/src/java/com/sun/xml/messaging/saaj/soap/impl/HeaderImpl.java
@@ -131,7 +131,7 @@ public abstract class HeaderImpl extends ElementImpl implements SOAPHeader {
         return getHeaderElementsForActor(actor, true, false);
     }
 
-    protected Iterator getHeaderElementsForActor(
+    protected Iterator<SOAPHeaderElement> getHeaderElementsForActor(
         String actor,
         boolean detach,
         boolean mustUnderstand) {
@@ -142,15 +142,15 @@ public abstract class HeaderImpl extends ElementImpl implements SOAPHeader {
         return getHeaderElements(actor, detach, mustUnderstand);
     }
 
-    protected Iterator getHeaderElements(
+    protected Iterator<SOAPHeaderElement> getHeaderElements(
         String actor,
         boolean detach,
         boolean mustUnderstand) {
-        List elementList = new ArrayList();
+        List<SOAPHeaderElement> elementList = new ArrayList<SOAPHeaderElement>();
 
-        Iterator eachChild = getChildElements();
+        Iterator<Node> eachChild = getChildElements();
 
-        Object currentChild = iterate(eachChild);
+        Node currentChild = iterate(eachChild);
         while (currentChild != null) {
             if (!(currentChild instanceof SOAPHeaderElement)) {
                 currentChild = iterate(eachChild);
@@ -188,7 +188,7 @@ public abstract class HeaderImpl extends ElementImpl implements SOAPHeader {
         return elementList.listIterator();
     }
 
-    private Object iterate(Iterator each) {
+    private <T> T iterate(Iterator<T> each) {
         return each.hasNext() ? each.next() : null;
     }
 

--- a/saaj-ri/src/java/com/sun/xml/messaging/saaj/soap/ver1_2/Fault1_2Impl.java
+++ b/saaj-ri/src/java/com/sun/xml/messaging/saaj/soap/ver1_2/Fault1_2Impl.java
@@ -161,7 +161,7 @@ public class Fault1_2Impl extends FaultImpl {
             findReasonElement();
         Iterator eachTextElement =
             this.faultStringElement.getChildElements(textName);
-        List texts = new ArrayList();
+        List<String> texts = new ArrayList<String>();
         while (eachTextElement.hasNext()) {
             SOAPElement textElement = (SOAPElement) eachTextElement.next();
             Locale thisLocale = getLocale(textElement);
@@ -250,7 +250,7 @@ public class Fault1_2Impl extends FaultImpl {
             findReasonElement();
         Iterator eachTextElement =
             this.faultStringElement.getChildElements(textName);
-        List localeSet = new ArrayList();
+        List<Locale> localeSet = new ArrayList<Locale>();
         while (eachTextElement.hasNext()) {
             SOAPElement textElement = (SOAPElement) eachTextElement.next();
             Locale thisLocale = getLocale(textElement);
@@ -450,7 +450,7 @@ public class Fault1_2Impl extends FaultImpl {
     public Iterator getFaultSubcodes() {
         if (this.faultCodeElement == null)
             findFaultCodeElement();
-        final List subcodeList = new ArrayList();
+        final List<QName> subcodeList = new ArrayList<QName>();
         SOAPElement currentCodeElement = this.faultCodeElement;
         Iterator subcodeElements =
             currentCodeElement.getChildElements(subcodeName);
@@ -464,14 +464,14 @@ public class Fault1_2Impl extends FaultImpl {
             subcodeElements = currentCodeElement.getChildElements(subcodeName);
         }
         //return subcodeList.iterator();
-        return new Iterator() {
-            Iterator subCodeIter = subcodeList.iterator();
+        return new Iterator<QName>() {
+            Iterator<QName> subCodeIter = subcodeList.iterator();
 
             public boolean hasNext() {
                 return subCodeIter.hasNext();
             }
 
-            public Object next() {
+            public QName next() {
                 return subCodeIter.next();
             }
 

--- a/saaj-ri/src/java/com/sun/xml/messaging/saaj/util/FastInfosetReflection.java
+++ b/saaj-ri/src/java/com/sun/xml/messaging/saaj/util/FastInfosetReflection.java
@@ -59,7 +59,7 @@ public class FastInfosetReflection {
     /**
      * FI DOMDocumentParser constructor using reflection.
      */
-    static Constructor fiDOMDocumentParser_new;
+    static Constructor<?> fiDOMDocumentParser_new;
     
     /**
      * FI <code>DOMDocumentParser.parse()</code> method via reflection.
@@ -69,7 +69,7 @@ public class FastInfosetReflection {
     /**
      * FI DOMDocumentSerializer constructor using reflection.
      */
-    static Constructor fiDOMDocumentSerializer_new;
+    static Constructor<?> fiDOMDocumentSerializer_new;
     
     /**
      * FI <code>FastInfosetSource.serialize(Document)</code> method via reflection.
@@ -84,12 +84,12 @@ public class FastInfosetReflection {
     /**
      * FI FastInfosetSource constructor using reflection.
      */
-    static Class fiFastInfosetSource_class;
+    static Class<?> fiFastInfosetSource_class;
     
     /**
      * FI FastInfosetSource constructor using reflection.
      */
-    static Constructor fiFastInfosetSource_new;
+    static Constructor<?> fiFastInfosetSource_new;
     
     /**
      * FI <code>FastInfosetSource.getInputStream()</code> method via reflection.
@@ -104,7 +104,7 @@ public class FastInfosetReflection {
     /**
      * FI FastInfosetResult constructor using reflection.
      */
-    static Constructor fiFastInfosetResult_new;
+    static Constructor<?> fiFastInfosetResult_new;
     
     /**
      * FI <code>FastInfosetResult.getOutputSTream()</code> method via reflection.
@@ -113,7 +113,7 @@ public class FastInfosetReflection {
     
     static {
         try {
-            Class clazz = Class.forName("com.sun.xml.fastinfoset.dom.DOMDocumentParser");
+            Class<?> clazz = Class.forName("com.sun.xml.fastinfoset.dom.DOMDocumentParser");
             fiDOMDocumentParser_new = clazz.getConstructor((Class[]) null);
             fiDOMDocumentParser_parse = clazz.getMethod("parse",
                 new Class[] { org.w3c.dom.Document.class, java.io.InputStream.class });
@@ -194,7 +194,7 @@ public class FastInfosetReflection {
             "org.jvnet.fastinfoset.FastInfosetSource");
     }
 
-    public static Class getFastInfosetSource_class() {
+    public static Class<?> getFastInfosetSource_class() {
         if (fiFastInfosetSource_class == null) {
             throw new RuntimeException("Unable to locate Fast Infoset implementation");
         }

--- a/saaj-ri/src/java/com/sun/xml/messaging/saaj/util/FinalArrayList.java
+++ b/saaj-ri/src/java/com/sun/xml/messaging/saaj/util/FinalArrayList.java
@@ -47,7 +47,7 @@ import java.util.Collection;
  * {@link ArrayList} with a final marker to help JIT.
  * @author Kohsuke Kawaguchi
  */
-public final class FinalArrayList extends ArrayList {
+public final class FinalArrayList<E> extends ArrayList<E> {
     public FinalArrayList(int initialCapacity) {
         super(initialCapacity);
     }
@@ -55,7 +55,7 @@ public final class FinalArrayList extends ArrayList {
     public FinalArrayList() {
     }
 
-    public FinalArrayList(Collection collection) {
+    public FinalArrayList(Collection<? extends E> collection) {
         super(collection);
     }
 

--- a/saaj-ri/src/java/com/sun/xml/messaging/saaj/util/stax/SaajStaxWriter.java
+++ b/saaj-ri/src/java/com/sun/xml/messaging/saaj/util/stax/SaajStaxWriter.java
@@ -330,12 +330,12 @@ public class SaajStaxWriter implements XMLStreamWriter {
                 return currentElement.lookupPrefix(namespaceURI);
             }
             public Iterator getPrefixes(final String namespaceURI) {
-                return new Iterator() {
+                return new Iterator<String>() {
                     String prefix = getPrefix(namespaceURI);
                     public boolean hasNext() {
                         return (prefix != null);
                     }
-                    public Object next() {
+                    public String next() {
                         if (!hasNext()) throw new java.util.NoSuchElementException();
                         String next = prefix;
                         prefix = null;

--- a/saaj-ri/src/java/com/sun/xml/messaging/saaj/util/stax/SaajStaxWriterEx.java
+++ b/saaj-ri/src/java/com/sun/xml/messaging/saaj/util/stax/SaajStaxWriterEx.java
@@ -130,12 +130,12 @@ public class SaajStaxWriterEx extends SaajStaxWriter implements XMLStreamWriterE
                 return currentElement.lookupPrefix(namespaceURI);
             }
             public Iterator getPrefixes(final String namespaceURI) {
-                return new Iterator() {
+                return new Iterator<String>() {
                     String prefix = getPrefix(namespaceURI);
                     public boolean hasNext() {
                         return (prefix != null);
                     }
-                    public Object next() {
+                    public String next() {
                         if (prefix == null) throw new java.util.NoSuchElementException();
                         String next = prefix;
                         prefix = null;


### PR DESCRIPTION
Java 5 introduced generics which provides stronger type checks at
compile time, eliminates casts and enables programmers to implement
generic algorithms.

The return type of public API methods has not been changed although
that would be backward compatible due to type type erasure.

Due to type erasure these changes should be backward compatible.