### PR TITLE
SAAJ-82 HttpSOAPConnection changes HttpURLConnection

### DIFF
--- a/saaj-ri/src/java/com/sun/xml/messaging/saaj/client/p2p/HttpSOAPConnection.java
+++ b/saaj-ri/src/java/com/sun/xml/messaging/saaj/client/p2p/HttpSOAPConnection.java
@@ -456,7 +456,7 @@ class HttpSOAPConnection extends SOAPConnection {
             httpConnection.setDoOutput(true);
             httpConnection.setDoInput(true);
             httpConnection.setUseCaches(false);
-            httpConnection.setFollowRedirects(true);
+            httpConnection.setInstanceFollowRedirects(true);
 
             httpConnection.connect();
 


### PR DESCRIPTION
HttpSOAPConnection calls the static method
java.net.HttpURLConnection#setFollowRedirects(boolean) which changes
the global HttpURLConnection configuration. It probably meant to call
the java.net.HttpURLConnection#setInstanceFollowRedirects(boolean)
instance method.

Issue: SAAJ-82
https://java.net/jira/browse/SAAJ-82