### PR TITLE
Don't access static members through instance

### DIFF
--- a/saaj-ri/src/java/com/sun/xml/messaging/saaj/soap/StaxLazySourceBridge.java
+++ b/saaj-ri/src/java/com/sun/xml/messaging/saaj/soap/StaxLazySourceBridge.java
@@ -42,6 +42,7 @@ package com.sun.xml.messaging.saaj.soap;
 
 import javax.xml.namespace.QName;
 import javax.xml.soap.SOAPException;
+import javax.xml.stream.XMLStreamConstants;
 import javax.xml.stream.XMLStreamException;
 import javax.xml.stream.XMLStreamReader;
 import javax.xml.stream.XMLStreamWriter;
@@ -91,7 +92,7 @@ public class StaxLazySourceBridge extends StaxBridge {
     public String getPayloadAttributeValue(String attName) {
         if (lazySource.isPayloadStreamReader()) {
             XMLStreamReader reader = lazySource.readPayload();
-            if (reader.getEventType() == reader.START_ELEMENT) {
+            if (reader.getEventType() == XMLStreamConstants.START_ELEMENT) {
                 return reader.getAttributeValue(null, attName);
             }
         }
@@ -102,7 +103,7 @@ public class StaxLazySourceBridge extends StaxBridge {
     public String getPayloadAttributeValue(QName attName) {
         if (lazySource.isPayloadStreamReader()) {
             XMLStreamReader reader = lazySource.readPayload();
-            if (reader.getEventType() == reader.START_ELEMENT) {
+            if (reader.getEventType() == XMLStreamConstants.START_ELEMENT) {
                 return reader.getAttributeValue(attName.getNamespaceURI(), attName.getLocalPart());
             }
         }

--- a/saaj-ri/src/java/com/sun/xml/messaging/saaj/soap/StaxReaderBridge.java
+++ b/saaj-ri/src/java/com/sun/xml/messaging/saaj/soap/StaxReaderBridge.java
@@ -42,6 +42,7 @@ package com.sun.xml.messaging.saaj.soap;
 
 import javax.xml.namespace.QName;
 import javax.xml.soap.SOAPException;
+import javax.xml.stream.XMLStreamConstants;
 import javax.xml.stream.XMLStreamReader;
 
 import org.jvnet.staxex.util.XMLStreamReaderToXMLStreamWriter;
@@ -80,14 +81,14 @@ public class StaxReaderBridge extends StaxBridge {
     }
 
     public QName getPayloadQName() {
-        return (in.getEventType() == in.START_ELEMENT) ? in.getName() : null;
+        return (in.getEventType() == XMLStreamConstants.START_ELEMENT) ? in.getName() : null;
     }
     
     public String getPayloadAttributeValue(String attName) {
-        return (in.getEventType() == in.START_ELEMENT) ? in.getAttributeValue(null, attName) : null;
+        return (in.getEventType() == XMLStreamConstants.START_ELEMENT) ? in.getAttributeValue(null, attName) : null;
     }
 
     public String getPayloadAttributeValue(QName attName) {
-        return (in.getEventType() == in.START_ELEMENT) ? in.getAttributeValue(attName.getNamespaceURI(), attName.getLocalPart()) : null;
+        return (in.getEventType() == XMLStreamConstants.START_ELEMENT) ? in.getAttributeValue(attName.getNamespaceURI(), attName.getLocalPart()) : null;
     }
 }


### PR DESCRIPTION
StaxLazySourceBridge and StaxReaderBridge access static fields of
XMLStreamConstants through a reader instance. This is generally
discouraged.

https://docs.oracle.com/javase/1.5.0/docs/guide/language/static-import.html